### PR TITLE
set latest compatible (v2.0.3) with Elastic 2.x version of HQ plugin

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,6 +1,6 @@
 FROM elasticsearch:2.4.3
 
-RUN /usr/share/elasticsearch/bin/plugin install --batch royrusso/elasticsearch-HQ
+RUN /usr/share/elasticsearch/bin/plugin install --batch royrusso/elasticsearch-HQ/v2.0.3
 RUN /usr/share/elasticsearch/bin/plugin install --batch lmenezes/elasticsearch-kopf
 
 COPY docker-healthcheck /usr/local/bin/


### PR DESCRIPTION
By default `/plugin install --batch royrusso/elasticsearch-HQ` trying to install latest master, recently updated to version v5.0.0 and has no backward compatibility with Elastic 2.x. 

This causes the following error:
```
ERROR: Plugin [hq] is a site plugin but has no '_site/' directory
```